### PR TITLE
Update packages and clean up project configurations

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@
 		<Version>0.0.0</Version>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<NoWarn>1701;1702;CS1591;CS8002;NETSDK1023;UXAML0002;NU5104;NETSDK1057;XC0103;NU1608</NoWarn>
+		<NoWarn>1701;1702;CS1591;CS8002;NETSDK1023;UXAML0002;NU5104;NETSDK1057;XC0103;NU1608;</NoWarn>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>..\..\I-Synergy.Framework.snk</AssemblyOriginatorKeyFile>
 		<AssemblyOriginatorKeyFile Condition="EXISTS('..\..\..\..\..\..\I-Synergy.Framework.snk')">..\..\..\..\..\..\I-Synergy.Framework.snk</AssemblyOriginatorKeyFile>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Azure.Identity" Version="1.17.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.17.1" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.5.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.26.0" />
@@ -17,7 +17,7 @@
     <PackageVersion Include="Dotmim.Sync.SqlServer.ChangeTracking" Version="1.3.0" />
     <PackageVersion Include="Dotmim.Sync.Web.Client" Version="1.3.0" />
     <PackageVersion Include="Dotmim.Sync.Web.Server" Version="1.3.0" />
-    <PackageVersion Include="DYMO.Connect.SDK" Version="1.4.8.13-beta" />
+    <PackageVersion Include="DYMO.Connect.SDK" Version="1.5.1.46-beta" />
     <PackageVersion Include="Mapster" Version="7.4.0" />
     <PackageVersion Include="MessagePack" Version="3.1.4" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
@@ -48,7 +48,7 @@
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.13.1" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.13.1" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.13.1" />
-    <PackageVersion Include="Microsoft.Graph" Version="5.96.0" />
+    <PackageVersion Include="Microsoft.Graph" Version="5.97.0" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.79.2" />
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.10" />
@@ -92,6 +92,5 @@
     <PackageVersion Include="Syncfusion.SfInput.WPF" Version="31.2.12" />
     <PackageVersion Include="Syncfusion.SfNavigationDrawer.WPF" Version="31.2.12" />
     <PackageVersion Include="Syncfusion.XlsIO.Net.Core" Version="31.2.12" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
   </ItemGroup>
 </Project>

--- a/src/ISynergy.Framework.UI.Blazor/ISynergy.Framework.UI.Blazor.csproj
+++ b/src/ISynergy.Framework.UI.Blazor/ISynergy.Framework.UI.Blazor.csproj
@@ -20,7 +20,6 @@
 		<PackageReference Include="Microsoft.Extensions.Http.Resilience" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.Authorization" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ISynergy.Framework.UI.Maui/ISynergy.Framework.UI.Maui.csproj
+++ b/src/ISynergy.Framework.UI.Maui/ISynergy.Framework.UI.Maui.csproj
@@ -3,8 +3,6 @@
 		<TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
 
-		<!-- https://github.com/CommunityToolkit/Maui/issues/2921 -->
-		<NoWarn>NU1608</NoWarn>
 		<MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>


### PR DESCRIPTION
- Updated `Azure.Identity` to 1.17.1, `DYMO.Connect.SDK` to 1.5.1.46-beta, and `Microsoft.Graph` to 5.97.0.
- Removed `System.IdentityModel.Tokens.Jwt` package reference.
- Removed commented-out `<NoWarn>` for `NU1608` in `ISynergy.Framework.UI.Maui.csproj`.
- General cleanup to improve compatibility and streamline configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated key dependencies including Azure.Identity to 1.17.1, Microsoft.Graph to 5.97.0, and DYMO.Connect.SDK to the latest beta release
  * Removed System.IdentityModel.Tokens.Jwt package dependency from the Blazor UI project
  * Updated build configuration settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->