### PR TITLE
esolve MAUI XAML source generator error with nested markup extensions

### DIFF
--- a/samples/Sample.Maui/Resources/Styles/Style.xaml
+++ b/samples/Sample.Maui/Resources/Styles/Style.xaml
@@ -959,7 +959,13 @@
         TargetType="Button">
         <Setter Property="MinimumWidthRequest" Value="64" />
         <Setter Property="ToolTipProperties.Text" Value="{m:GetString Refresh}" />
-        <Setter Property="Text" Value="{OnPlatform WinUI={m:GetString Refresh}}" />
+        <Setter Property="Text">
+            <Setter.Value>
+                <OnPlatform x:TypeArguments="x:String">
+                    <On Platform="WinUI" Value="{m:GetString Refresh}" />
+                </OnPlatform>
+            </Setter.Value>
+        </Setter>
         <Setter Property="ImageSource">
             <FontImageSource
                 FontFamily="FontAwesomeRegular"


### PR DESCRIPTION
The Release mode build was failing with error MAUIG1001: "Value cannot be null. (Parameter 'key')" on iOS, Android, and macCatalyst platforms.

Root cause: The MAUI XAML source generator cannot parse nested markup extensions when a custom markup extension ({m:GetString}) is used inside another markup extension ({OnPlatform}).

Fix: Changed the RefreshButtonStyle's Text property from inline nested syntax:
  Value="{OnPlatform WinUI={m:GetString Refresh}}"

To expanded element syntax:
  <OnPlatform x:TypeArguments="x:String">
    <On Platform="WinUI" Value="{m:GetString Refresh}" />
  </OnPlatform>

This allows the source generator to properly parse and defer the custom markup extension evaluation to runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated internal styling structure for improved consistency and maintainability.

**Note:** This release contains no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->