### PR TITLE
chore: update NuGet packages to latest stable versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,10 +4,10 @@
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Azure.Identity" Version="1.19.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.20.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.9.0" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.6.0" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageVersion Include="AWSSDK.S3" Version="4.0.19.4" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
@@ -27,9 +27,9 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.5" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.2.0" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.2.0" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.2.1" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.2.1" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.2.1" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
@@ -64,7 +64,7 @@
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.14.0" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.14.0" />
     <PackageVersion Include="Microsoft.Graph" Version="5.103.0" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.83.1" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.83.3" />
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.51" />
     <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.51" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
@@ -95,22 +95,22 @@
     <PackageVersion Include="Reqnroll.MSTest" Version="3.3.4" />
     <PackageVersion Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.4" />
     <PackageVersion Include="SendGrid" Version="9.29.3" />
-    <PackageVersion Include="Sentry" Version="6.2.0" />
-    <PackageVersion Include="Sentry.OpenTelemetry" Version="6.2.0" />
+    <PackageVersion Include="Sentry" Version="6.3.0" />
+    <PackageVersion Include="Sentry.OpenTelemetry" Version="6.3.0" />
     <PackageVersion Include="SkiaSharp" Version="3.119.2" />
     <!-- Pin to 2.1.10+ to provide 16KB page-aligned libe_sqlite3.so for Android 16 (XA0141).
          Dotmim.Sync.Sqlite 1.3.0 pulls 2.1.6 transitively; the managed API is unchanged. -->
     <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3.android" Version="2.1.11" />
-    <PackageVersion Include="Syncfusion.Chart.WinUI" Version="33.1.45" />
-    <PackageVersion Include="Syncfusion.DocIO.Net.Core" Version="33.1.45" />
-    <PackageVersion Include="Syncfusion.DocIORenderer.Net.Core" Version="33.1.45" />
-    <PackageVersion Include="Syncfusion.Editors.WinUI" Version="33.1.45" />
-    <PackageVersion Include="Syncfusion.Gauge.WinUI" Version="33.1.45" />
-    <PackageVersion Include="Syncfusion.Licensing" Version="33.1.45" />
-    <PackageVersion Include="Syncfusion.Maui.Core" Version="33.1.45" />
-    <PackageVersion Include="Syncfusion.Pdf.Net.Core" Version="33.1.45" />
-    <PackageVersion Include="Syncfusion.SfInput.WPF" Version="33.1.45" />
-    <PackageVersion Include="Syncfusion.SfNavigationDrawer.WPF" Version="33.1.45" />
-    <PackageVersion Include="Syncfusion.XlsIO.Net.Core" Version="33.1.45" />
+    <PackageVersion Include="Syncfusion.Chart.WinUI" Version="33.1.46" />
+    <PackageVersion Include="Syncfusion.DocIO.Net.Core" Version="33.1.46" />
+    <PackageVersion Include="Syncfusion.DocIORenderer.Net.Core" Version="33.1.46" />
+    <PackageVersion Include="Syncfusion.Editors.WinUI" Version="33.1.46" />
+    <PackageVersion Include="Syncfusion.Gauge.WinUI" Version="33.1.46" />
+    <PackageVersion Include="Syncfusion.Licensing" Version="33.1.46" />
+    <PackageVersion Include="Syncfusion.Maui.Core" Version="33.1.46" />
+    <PackageVersion Include="Syncfusion.Pdf.Net.Core" Version="33.1.46" />
+    <PackageVersion Include="Syncfusion.SfInput.WPF" Version="33.1.46" />
+    <PackageVersion Include="Syncfusion.SfNavigationDrawer.WPF" Version="33.1.46" />
+    <PackageVersion Include="Syncfusion.XlsIO.Net.Core" Version="33.1.46" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Azure.Identity 1.19.0 → 1.20.0
- Azure.Monitor.OpenTelemetry.Exporter 1.6.0 → 1.7.0
- Aspire.Hosting.* 13.2.0 → 13.2.1
- Microsoft.Identity.Client 4.83.1 → 4.83.3
- Sentry + Sentry.OpenTelemetry 6.2.0 → 6.3.0
- Syncfusion (all 11 packages) 33.1.45 → 33.1.46

87 packages were already at the latest stable version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)